### PR TITLE
WIP Add Run on Gradient Button

### DIFF
--- a/XGBoost/README.md
+++ b/XGBoost/README.md
@@ -1,4 +1,8 @@
 # XGBoost Notebooks
+
+[![Gradient](https://assets.paperspace.io/img/gradient-badge.svg)](https://console.paperspace.com/github/gradient-ai/RAPIDS/master/XGBoost/XGBoost_Demo.ipynb)
+
+
 ## Intro
 These notebooks provide examples of how to use XGBoost.  These notebooks are designed to be self-contained with the `runtime` version of the [RAPIDS Docker Container](https://hub.docker.com/r/rapidsai/rapidsai/) and [RAPIDS Nightly Docker Containers](https://hub.docker.com/r/rapidsai/rapidsai-nightly) and can run on air-gapped systems.  You can quickly get this container using the install guide from the [RAPIDS.ai Getting Started page](https://rapids.ai/start.html#get-rapids)
 
@@ -9,4 +13,6 @@ Notebook Title | Status | Description
 
 ## RAPIDS notebooks
 Visit the main RAPIDS [notebooks](https://github.com/rapidsai/notebooks) repo for a listing of all notebooks across all RAPIDS libraries.
+
+
 


### PR DESCRIPTION
Hi There 👋 ! We noticed you are running jupyter notebooks with Google Colab today. 

—

## What it is:

The Run on Gradient badge allows you to run a Gradient Notebook from any public GitHub repository on a free GPU.  Gradient Notebooks are a hosted Jupyter notebook service from Paperspace that requires no setup and provides free access to computing resources including GPUs.

## How it Works:

Clicking the badge will take you to a static page where you can view the full contents of the notebook. From this page, you can either sign in or create an account to run the notebook for free. Making an account is totally free and can be done in a few clicks by signing up with Google, GitHub, or email. Then just select “Run Notebook on a Free GPU” and Gradient will spin up a free, fully interactive notebook instance.

## FAQ:

* What is Gradient?

Gradient is an end-to-end ML platform created by Paperspace that simplifies development, training, and deployment of deep learning models. It consists of a web interface, CLI, and SDK. You can use Gradient to run Jupyter notebooks on powerful cloud GPUs with zero configuration required.

* Who is Paperspace?

Paperspace is a cloud computing platform for developing and hosting accelerated applications. Hundreds of thousands of individuals, startups, and enterprises use Paperspace to power a range of applications in deep learning, VFX, and anywhere else compute-intensive resources are required.

* Is it really free to use?

Yes, Gradient notebooks are really (and totally) free. We allow developers to use our spare compute capacity for free and provide options to upgrade to even more powerful paid instances. Gradient notebooks are the recommended resource by Jeremy Howard to complete the fast.ai (https://www.fast.ai/) course. 

* Where can I learn more?

You can always learn more in our docs (https://docs.paperspace.com/gradient/), or by reaching out. We’re happy to answer any questions! 

